### PR TITLE
Fix three defects from code review

### DIFF
--- a/gff_utils/gff_transcript_quality_filter.R
+++ b/gff_utils/gff_transcript_quality_filter.R
@@ -22,7 +22,7 @@ read_gff_as_df = function(path) {
 
 # Create helper function for adding in stop and start codon information (needed for ensembl). 
 add_stop_start = function(cds, to_keep, strand = "+", start = TRUE) {
-  cds_strand = cds %>% filter(strand == strand)
+  cds_strand = cds %>% filter(strand == .env$strand)
   if (nrow(cds_strand) == 0) return(cds_strand[0, ])
 
   if (start && strand == "+") {

--- a/rules/genome_windows.smk
+++ b/rules/genome_windows.smk
@@ -266,7 +266,6 @@ rule call_enriched_windows:
             {params.threshold_min} \
             {params.normalization_mode} \
             {params.blacklist} \
-            
         >> {log.stdout} 2> {log.stderr}
 
         echo "[`date`] Finished call_enriched_windows" | tee -a {log.stdout}

--- a/tools/call_enriched_windows.R
+++ b/tools/call_enriched_windows.R
@@ -29,7 +29,7 @@ if(length(args) > 9) {
 } else {
 	blacklist = tibble(chr=character(),start=numeric(),end=numeric(),name=character(),score=numeric(),strand=character())
 }
-count_data = anti_join(count_data, blacklist %>% select(-name))
+count_data = anti_join(count_data, blacklist, by = c("chr", "start", "end", "strand"))
 
 # Convenience link functions on base-2 scale for logits and inverse-logits. 
 logisticb2 = function(x) 1 / (1 + 2**-x)


### PR DESCRIPTION
1. gff_transcript_quality_filter.R: filter(strand == strand) was shadowed by the column under dplyr data-masking, so add_stop_start ignored its strand argument and mixed +/- CDS rows. Use .env$strand.
2. call_enriched_windows.R: blacklist anti_join had no by=, so it joined on all shared columns including score and silently skipped removal when scores differed. Join on c(chr, start, end, strand).
3. genome_windows.smk: a whitespace-only line after the trailing backslash detached the log redirect, so call_enriched_windows.R output was never captured. Remove the blank line.

(Reviewed a fourth candidate -- log2(norm_clip / norm_input) divide-by-zero in the "new" normalization mode -- but it is already handled: the line-47 filter guarantees input + clip > 0, and the threshold_min >= 2 output filter removes the only windows (total == 1) that can round a count to 0. Left unchanged.)